### PR TITLE
Security Fix for Path traversal on <s>"min-http-server" - huntr.dev

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ app.use( async ( ctx ) => {
   // 静态资源目录在本地的绝对路径
   let fullStaticPath = staticPath
 
+  // prevent directory traversal (预防漏洞)
   if (ctx.request.url.includes('..')) {
     ctx.res.writeHead(403)
     let message = '<h2>Forbidden</h2><p>The requested file cannot be accessed.</p>'

--- a/index.js
+++ b/index.js
@@ -22,6 +22,13 @@ app.use( async ( ctx ) => {
   // 静态资源目录在本地的绝对路径
   let fullStaticPath = staticPath
 
+  if (ctx.request.url.includes('..')) {
+    ctx.res.writeHead(403)
+    let message = '<h2>Forbidden</h2><p>The requested file cannot be accessed.</p>'
+    ctx.res.write(message, 'buffer')
+    ctx.res.end()
+  }
+
   // 获取静态资源内容，有可能是文件内容，目录，或404
   let _content = await content( ctx, fullStaticPath )
 


### PR DESCRIPTION
https://huntr.dev/users/mufeedvh has fixed the Path traversal on <s>"min-http-server" vulnerability 🔨. mufeedvh has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/min-http-server/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/min-http-server/1/README.md

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-min-http-server

### ⚙️ Description *

The module `min-http-server` was vulnerable to **Path Traversal** as it didn't check for trailing slashes in the requested path and reads the file which can lead to **Information Disclosure**.

### 💻 Technical Description *

**Path Traversal** is a common vulnerability among webservers although popular ones will already/initially have a patch for this issue by simply not allowing anyone to access the files outside the project directory. These are implemented with a **Forbidden** message to show that the file cannot be accessed. This same implementation is adopted in this fix.

### 🐛 Proof of Concept (PoC) *

    $ node index.js
    $ curl --path-as-is http://localhost:3002/../../../../../../etc/passwd

### 🔥 Proof of Fix (PoF) *

![Screenshot from 2020-09-05 00-15-20](https://user-images.githubusercontent.com/26198477/92275760-54877c00-ef0d-11ea-906d-15414c86f6bb.png)

![Screenshot from 2020-08-25 23-26-15](https://user-images.githubusercontent.com/26198477/91211262-1f6c7400-e72c-11ea-96e7-18068bd49014.png)

### 👍 User Acceptance Testing (UAT)

**OK** :+1:

The comment has Chinese as all the other comments are also in Chinese. :)

```
// prevent directory traversal (预防漏洞)
```

**预防漏洞** means **Prevent vulnerabilities**. :)
